### PR TITLE
feat: add create note page and update UI to link to it

### DIFF
--- a/app/notes/create/CreateNotePage.module.css
+++ b/app/notes/create/CreateNotePage.module.css
@@ -1,0 +1,14 @@
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  text-align: center;
+  color: #333;
+  margin-bottom: 1.5rem;
+}

--- a/app/notes/create/page.tsx
+++ b/app/notes/create/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import NoteForm from "@/components/NoteForm/NoteForm";
+import { useRouter } from "next/navigation";
+import css from "./CreateNotePage.module.css";
+
+export default function CreateNotePage() {
+  const router = useRouter();
+
+  const handleClose = () => {
+    router.push("/notes/filter/all"); // Redirect to the main notes list page
+  };
+
+  return (
+    <div className={css.container}>
+      <h1 className={css.title}>Create New Note</h1>
+      <NoteForm onClose={handleClose} />
+    </div>
+  );
+}

--- a/app/notes/filter/[...slug]/Notes.client.tsx
+++ b/app/notes/filter/[...slug]/Notes.client.tsx
@@ -11,7 +11,7 @@ import ErrorMessage from "@/components/ErrorMessage/ErrorMessage";
 import Loader from "@/components/Loader/Loader";
 import NoteList from "@/components/NoteList/NoteList";
 import { fetchNotes, NotesResponse } from "@/lib/api";
-import Modal from "@/components/Modal/Modal";
+import Link from "next/link";
 import NoteForm from "@/components/NoteForm/NoteForm";
 
 interface NotesProps {
@@ -23,7 +23,6 @@ function Notes({ initialData, tag }: NotesProps) {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [debouncedSearchQuery] = useDebounce(searchQuery, 300);
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
   const { data, isError, isPending } = useQuery({
     queryKey: ["noteList", tag, debouncedSearchQuery, currentPage],
     queryFn: () => fetchNotes(currentPage, debouncedSearchQuery, tag),
@@ -40,10 +39,6 @@ function Notes({ initialData, tag }: NotesProps) {
     setSearchQuery(text);
   };
 
-  const closeModal = () => {
-    setIsOpenModal(false);
-  };
-
   return (
     <div className={css.app}>
       <header className={css.toolbar}>
@@ -56,15 +51,10 @@ function Notes({ initialData, tag }: NotesProps) {
           />
         )}
 
-        <button onClick={() => setIsOpenModal(true)} className={css.button}>
+        <Link href="/notes/create" className={css.button}>
           Create note +
-        </button>
+        </Link>
       </header>
-      {isOpenModal && (
-        <Modal closeModal={closeModal}>
-          <NoteForm onClose={closeModal} />
-        </Modal>
-      )}
       {isPending && <Loader />}
       {data?.notes && <NoteList list={data.notes} />}
       {isError && <ErrorMessage />}


### PR DESCRIPTION
- Added a new page at `/notes/create` for creating notes.
- This page uses the existing `NoteForm` component.
- Replaced the modal-opening button in the notes list with a Next.js Link component that navigates to the new create page.
- Removed unused modal-related state and components from the notes list page.